### PR TITLE
Change params

### DIFF
--- a/contracts/Collectibles.sol
+++ b/contracts/Collectibles.sol
@@ -31,10 +31,13 @@ contract Collectibles is Ownable, ERC721Token {
 		_;
 	}
 
-	function mint(address _to, uint256 _tokenId, uint _copy, string _uri) public onlyAdmin {
-		super._mint(_to, _tokenId);
-		super._setTokenURI(_tokenId, _uri);
-		metadata[_tokenId].copy = _copy;
+	function mint(address _to, string _jsonHash, uint _copy, string _uri) public onlyAdmin {
+		uint tokenId = uint(keccak256(_jsonHash, _copy));
+		super._mint(_to, tokenId);
+
+		// TODO: shall we concatenate uri with _jsonHash?
+		super._setTokenURI(tokenId, _uri);
+		metadata[tokenId].copy = _copy;
 	}
 
 	function massMint(
@@ -49,8 +52,7 @@ contract Collectibles is Ownable, ERC721Token {
 
 		uint copy_end = _copyStart + _copies;
 		for (uint copy = _copyStart; copy < copy_end; copy++) {
-			uint tokenId = uint(keccak256(_jsonHash, copy));
-			mint(_to, tokenId, copy, _uri);
+			mint(_to, _jsonHash, copy, _uri);
 		}
 	}
 

--- a/contracts/Collectibles.sol
+++ b/contracts/Collectibles.sol
@@ -49,21 +49,6 @@ contract Collectibles is Ownable, ERC721Token {
 
 		uint copyEnd = _copyStart + _copiesCount;
 		for (uint copy = _copyStart; copy < copyEnd; copy++) {
-			mint(_to, _jsonHash, copy);
-		}
-	}
-
-	function massMintTolerant(
-		address _to,
-		string _jsonHash,      // sha3(pic, title, description)
-		uint _copyStart,
-		uint _copiesCount
-	) public onlyAdmin {
-
-		require(_copiesCount <= 10);
-
-		uint copyEnd = _copyStart + _copiesCount;
-		for (uint copy = _copyStart; copy < copyEnd; copy++) {
 			uint tokenId = uint(keccak256(_jsonHash, copy));
 
 			// skip tokens minted already

--- a/contracts/Collectibles.sol
+++ b/contracts/Collectibles.sol
@@ -45,6 +45,8 @@ contract Collectibles is Ownable, ERC721Token {
 		string _uri
 	) public onlyAdmin {
 
+		require(_copies <= 10);
+
 		uint copy_end = _copyStart + _copies;
 		for (uint copy = _copyStart; copy < copy_end; copy++) {
 			uint tokenId = uint(keccak256(_jsonHash, copy));
@@ -59,6 +61,8 @@ contract Collectibles is Ownable, ERC721Token {
 		uint _copies,
 		string _uri
 	) public onlyAdmin {
+
+		require(_copies <= 10);
 
 		uint copy_end = _copyStart + _copies;
 		for (uint copy = _copyStart; copy < copy_end; copy++) {

--- a/contracts/Collectibles.sol
+++ b/contracts/Collectibles.sol
@@ -31,12 +31,10 @@ contract Collectibles is Ownable, ERC721Token {
 		_;
 	}
 
-	function mint(address _to, string _jsonHash, uint _copy, string _uri) public onlyAdmin {
+	function mint(address _to, string _jsonHash, uint _copy) public onlyAdmin {
 		uint tokenId = uint(keccak256(_jsonHash, _copy));
 		super._mint(_to, tokenId);
-
-		// TODO: shall we concatenate uri with _jsonHash?
-		super._setTokenURI(tokenId, _uri);
+		super._setTokenURI(tokenId, _jsonHash);
 		metadata[tokenId].copy = _copy;
 	}
 
@@ -44,15 +42,14 @@ contract Collectibles is Ownable, ERC721Token {
 		address _to,
 		string _jsonHash,      // sha3(pic, title, description)
 		uint _copyStart,
-		uint _copies,
-		string _uri
+		uint _copiesCount
 	) public onlyAdmin {
 
-		require(_copies <= 10);
+		require(_copiesCount <= 10);
 
-		uint copy_end = _copyStart + _copies;
-		for (uint copy = _copyStart; copy < copy_end; copy++) {
-			mint(_to, _jsonHash, copy, _uri);
+		uint copyEnd = _copyStart + _copiesCount;
+		for (uint copy = _copyStart; copy < copyEnd; copy++) {
+			mint(_to, _jsonHash, copy);
 		}
 	}
 
@@ -60,21 +57,22 @@ contract Collectibles is Ownable, ERC721Token {
 		address _to,
 		string _jsonHash,      // sha3(pic, title, description)
 		uint _copyStart,
-		uint _copies,
-		string _uri
+		uint _copiesCount
 	) public onlyAdmin {
 
-		require(_copies <= 10);
+		require(_copiesCount <= 10);
 
-		uint copy_end = _copyStart + _copies;
-		for (uint copy = _copyStart; copy < copy_end; copy++) {
+		uint copyEnd = _copyStart + _copiesCount;
+		for (uint copy = _copyStart; copy < copyEnd; copy++) {
 			uint tokenId = uint(keccak256(_jsonHash, copy));
 
 			// skip tokens minted already
 			if(exists(tokenId))
 				continue;
 
-			mint(_to, tokenId, copy, _uri);
+			super._mint(_to, tokenId);
+			super._setTokenURI(tokenId, _jsonHash);
+			metadata[tokenId].copy = copy;
 		}
 	}
 

--- a/contracts/Collectibles.sol
+++ b/contracts/Collectibles.sol
@@ -37,11 +37,41 @@ contract Collectibles is Ownable, ERC721Token {
 		metadata[_tokenId].copy = _copy;
 	}
 
-	function massMint(address[] _to, uint256 []_tokenId) public onlyAdmin {
-		for(uint32 index=0; index<_to.length; index++) {
-			super._mint(_to[index], _tokenId[index]);
+	function massMint(
+		address _to,
+		string _jsonHash,      // sha3(pic, title, description)
+		uint _copyStart,
+		uint _copies,
+		string _uri
+	) public onlyAdmin {
+
+		uint copy_end = _copyStart + _copies;
+		for (uint copy = _copyStart; copy < copy_end; copy++) {
+			uint tokenId = uint(keccak256(_jsonHash, copy));
+			mint(_to, tokenId, copy, _uri);
 		}
 	}
+
+	function massMintTolerant(
+		address _to,
+		string _jsonHash,      // sha3(pic, title, description)
+		uint _copyStart,
+		uint _copies,
+		string _uri
+	) public onlyAdmin {
+
+		uint copy_end = _copyStart + _copies;
+		for (uint copy = _copyStart; copy < copy_end; copy++) {
+			uint tokenId = uint(keccak256(_jsonHash, copy));
+
+			// skip tokens minted already
+			if(exists(tokenId))
+				continue;
+
+			mint(_to, tokenId, copy, _uri);
+		}
+	}
+
 
 	function setTokenURI(uint256 _tokenId, string _uri) public onlyAdmin {
 		super._setTokenURI(_tokenId, _uri);

--- a/contracts/Collectibles.sol
+++ b/contracts/Collectibles.sol
@@ -11,6 +11,7 @@ contract Collectibles is Ownable, ERC721Token {
 		uint32 timestamp;
 		uint amount;
 		string currency;
+		uint copy;
 	}
 
 	// Optional mapping for token metadata
@@ -30,8 +31,10 @@ contract Collectibles is Ownable, ERC721Token {
 		_;
 	}
 
-	function mint(address _to, uint256 _tokenId) public onlyAdmin {
+	function mint(address _to, uint256 _tokenId, uint _copy, string _uri) public onlyAdmin {
 		super._mint(_to, _tokenId);
+		super._setTokenURI(_tokenId, _uri);
+		metadata[_tokenId].copy = _copy;
 	}
 
 	function massMint(address[] _to, uint256 []_tokenId) public onlyAdmin {
@@ -48,10 +51,16 @@ contract Collectibles is Ownable, ERC721Token {
 		adaptAdmin = _newAdmin;
 	}
 
-	function setTokenMetadata(uint256 _tokenId, uint32 _timestamp, uint _amount, string currency) public canTransfer(_tokenId)  {
+	function setTokenMetadata(uint256 _tokenId, uint32 _timestamp, uint _amount, string _currency) public canTransfer(_tokenId)  {
 		TokenMetadata storage tm = metadata[_tokenId];
+
+		// this can be done once only
 		require(tm.timestamp == 0 && tm.amount == 0);
-		metadata[_tokenId] = TokenMetadata({timestamp : _timestamp, amount: _amount, currency: currency});
+
+		// update the metadata structure
+		metadata[_tokenId].timestamp = _timestamp;
+		metadata[_tokenId].amount = _amount;
+		metadata[_tokenId].currency = _currency;
 	}
 
 	function getTokenMetadata(uint256 _tokenId) public view returns (uint32 timestamp, uint amount) {

--- a/test/00-collectibles.test.js
+++ b/test/00-collectibles.test.js
@@ -91,7 +91,7 @@ contract('Collectibles', function (rpc_accounts) {
 	it('should let the admin to mass mint 5 more copies of the very same token', async function () {
 		let jsonHash = web3.sha3("dog-pic", "dog", "nice-dog").slice(2);
 
-		let result = await collectibles.massMintTolerant(
+		let result = await collectibles.massMint(
 			ac.ACCOUNT2,
 			jsonHash,
 			5,

--- a/test/00-collectibles.test.js
+++ b/test/00-collectibles.test.js
@@ -51,7 +51,6 @@ contract('Collectibles', function (rpc_accounts) {
 		assert.equal(balance, 2, 'unexpected balance');
 	});
 
-
 	it('should let token owner to set token metadata', async function () {
 		await collectibles.setTokenMetadata(0, 10000, 1, 1, {from: ac.ACCOUNT1, gas: 7000000}).should.be.fulfilled;
 		let metadata = await collectibles.getTokenMetadata(0);
@@ -76,13 +75,12 @@ contract('Collectibles', function (rpc_accounts) {
 		let uri = 'https://adaptk.it/j/' + jsonHash;
 		console.log('uri: ', uri);
 
-		let result = await collectibles.massMintTolerant(ac.ACCOUNT2, jsonHash, 5, 15, uri,
+		let result = await collectibles.massMintTolerant(ac.ACCOUNT2, jsonHash, 5, 10, uri,
 			{from: ac.ADAPT_ADMIN, gas: 7000000}).should.be.fulfilled;
 
 		console.log('gas: ', result.receipt.gasUsed);
 
-
 		let balance = await collectibles.balanceOf(ac.ACCOUNT2);
-		assert.equal(balance, 10, 'unexpected balance');
+		assert.equal(balance, 5, 'unexpected balance');
 	});
 });

--- a/test/00-collectibles.test.js
+++ b/test/00-collectibles.test.js
@@ -3,12 +3,17 @@ require('babel-polyfill');
 
 import EVMRevert from "../zeppelin/test/helpers/EVMRevert";
 import {accounts} from './common/common';
-
-let chai = require('chai');
-let assert = chai.assert;
-let Promise = require('bluebird');
-
 const Collectibles = artifacts.require("../contracts/Collectibles.sol");
+
+let Promise = require('bluebird');
+const BigNumber = web3.BigNumber;
+let chai = require('chai');
+let assert = require('chai').assert;
+const should = require('chai')
+	.use(require('chai-as-promised'))
+	.use(require('chai-bignumber')(BigNumber))
+	.should();
+
 
 contract('Collectibles', function (rpc_accounts) {
 
@@ -29,4 +34,28 @@ contract('Collectibles', function (rpc_accounts) {
 		console.log("collectibles.address= " +collectibles.address);
 	});
 
+	it('should let adapt admin to mint tokens', async function () {
+		await collectibles.mint(ac.ACCOUNT1, 0, 0, 'uri0', {from: ac.ADAPT_ADMIN, gas: 7000000}).should.be.fulfilled;
+		let uri = await collectibles.tokenURI(0);
+		assert.equal(uri, 'uri0', 'unexpected token uri');
+
+		await collectibles.mint(ac.ACCOUNT1, 1, 0, 'uri1', {from: ac.ADAPT_ADMIN, gas: 7000000}).should.be.fulfilled;
+		uri = await collectibles.tokenURI(1);
+		assert.equal(uri, 'uri1', 'unexpected token uri');
+
+		// duplicate token id  - expect reject
+		await collectibles.mint(ac.ACCOUNT1, 1, 0, 'uri', {from: ac.ADAPT_ADMIN, gas: 7000000}).should.be.rejectedWith(EVMRevert);
+
+		let balance = await collectibles.balanceOf(ac.ACCOUNT1);
+
+		assert.equal(balance, 2, 'unexpected balance');
+	});
+
+
+	it('should let token owner to set token metadata', async function () {
+		await collectibles.setTokenMetadata(0, 10000, 1, 1, {from: ac.ACCOUNT1, gas: 7000000}).should.be.fulfilled;
+		let metadata = await collectibles.getTokenMetadata(0);
+		assert.equal(metadata[0], 10000, 'unexpected timestamp');
+		assert.equal(metadata[1], 1, 'unexpected amount');
+	});
 });

--- a/test/00-collectibles.test.js
+++ b/test/00-collectibles.test.js
@@ -58,4 +58,31 @@ contract('Collectibles', function (rpc_accounts) {
 		assert.equal(metadata[0], 10000, 'unexpected timestamp');
 		assert.equal(metadata[1], 1, 'unexpected amount');
 	});
+
+	it('should let the owner to mass mint 10 copies of the very same token', async function () {
+		let jsonHash = web3.sha3("pic", "title", "description").slice(2);
+		let uri = 'https://adaptk.it/j/' + jsonHash;
+		console.log('uri: ', uri);
+		let result = await collectibles.massMint(ac.ADAPT_ADMIN, jsonHash, 0, 10, uri,
+			{from: ac.ADAPT_ADMIN, gas: 7000000}).should.be.fulfilled;
+		console.log('gas: ', result.receipt.gasUsed);
+
+		let balance = await collectibles.balanceOf(ac.ADAPT_ADMIN);
+		assert.equal(balance, 10, 'unexpected balance');
+	});
+
+	it('should let the owner to mass mint 10 more copies of the very same token', async function () {
+		let jsonHash = web3.sha3("pic", "title", "description").slice(2);
+		let uri = 'https://adaptk.it/j/' + jsonHash;
+		console.log('uri: ', uri);
+
+		let result = await collectibles.massMintTolerant(ac.ACCOUNT2, jsonHash, 5, 15, uri,
+			{from: ac.ADAPT_ADMIN, gas: 7000000}).should.be.fulfilled;
+
+		console.log('gas: ', result.receipt.gasUsed);
+
+
+		let balance = await collectibles.balanceOf(ac.ACCOUNT2);
+		assert.equal(balance, 10, 'unexpected balance');
+	});
 });

--- a/test/common/common.js
+++ b/test/common/common.js
@@ -5,6 +5,7 @@ function accounts(rpc_accounts) {
 		ADAPT_ADMIN: rpc_accounts[2],
 		ADAPT_WALLET: rpc_accounts[3],
 		ACCOUNT1: rpc_accounts[4],
+		ACCOUNT2: rpc_accounts[5],
 	};
 }
 

--- a/test/common/common.js
+++ b/test/common/common.js
@@ -4,6 +4,7 @@ function accounts(rpc_accounts) {
 		ADAPT_OWNER: rpc_accounts[1],
 		ADAPT_ADMIN: rpc_accounts[2],
 		ADAPT_WALLET: rpc_accounts[3],
+		ACCOUNT1: rpc_accounts[4],
 	};
 }
 


### PR DESCRIPTION
@imcu,

This is the most recent change. Please disregard the other pull request (I will delete it anyway).
I changed the params for mint, massMint and massMintTolerant (the name is weird).
As you can see, these functions won't take a URI anymore. The URI is exactly the JSON_HASH.
The copy attribute is set into the token metadata during minting.
